### PR TITLE
fix callable native module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-declare module 'react-native-clear-cache' {
+declare module "react-native-clear-cache" {
   export const ClearCache: {
     getAppCacheSize: () => { value: string; unit: string };
     clearAppCache: () => void;
   };
+  export default ClearCache;
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
 
-const { ReactNativeClearCache } = NativeModules;
+const { ClearCache } = NativeModules;
 
-export default ReactNativeClearCache;
+export default ClearCache;

--- a/ios/ClearCache-Bridging-Header.h
+++ b/ios/ClearCache-Bridging-Header.h
@@ -1,0 +1,3 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//

--- a/ios/ClearCache.m
+++ b/ios/ClearCache.m
@@ -1,6 +1,6 @@
 #import <React/RCTBridgeModule.h>
 
 @interface RCT_EXTERN_MODULE(ClearCache, NSObject)
-RCT_EXTERN_METHOD(getAppCacheSize)
-RCT_EXTERN_METHOD(clearAppCache)
+    RCT_EXTERN_METHOD(getAppCacheSize)
+    RCT_EXTERN_METHOD(clearAppCache)
 @end

--- a/ios/ClearCache.xcodeproj/project.pbxproj
+++ b/ios/ClearCache.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9137F8DF250FB84700C41D4E /* ClearCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9137F8DE250FB84700C41D4E /* ClearCache.swift */; };
+		DB0F67402518E359005DCFDA /* ClearCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0F673F2518E359005DCFDA /* ClearCache.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,7 +26,8 @@
 /* Begin PBXFileReference section */
 		9137F8DD250FB82E00C41D4E /* libClearCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libClearCache.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9137F8DE250FB84700C41D4E /* ClearCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearCache.swift; sourceTree = "<group>"; };
-		9137F8E0250FB85500C41D4E /* ClearCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClearCache.h; sourceTree = "<group>"; };
+		DB0F673F2518E359005DCFDA /* ClearCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClearCache.m; sourceTree = "<group>"; };
+		DB0F67422518E42F005DCFDA /* ClearCache-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ClearCache-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,7 +44,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				9137F8E0250FB85500C41D4E /* ClearCache.h */,
+				DB0F67422518E42F005DCFDA /* ClearCache-Bridging-Header.h */,
+				DB0F673F2518E359005DCFDA /* ClearCache.m */,
 				9137F8DE250FB84700C41D4E /* ClearCache.swift */,
 				9137F8DD250FB82E00C41D4E /* libClearCache.a */,
 			);
@@ -106,6 +109,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB0F67402518E359005DCFDA /* ClearCache.m in Sources */,
 				9137F8DF250FB84700C41D4E /* ClearCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
AOS, iOS에서 clearAppCache, getAppCacheSize를 불러쓸 수 있도록 수정함
타입을 지정한 변수를 export default로 내보내도록 수정함